### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -1,6 +1,8 @@
 # This starter workflow is for a CMake project running on multiple platforms. There is a different starter workflow if you just want a single platform.
 # See: https://github.com/actions/starter-workflows/blob/main/ci/cmake-single-platform.yml
 name: CMake on multiple platforms
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/sevki/libcrush/security/code-scanning/2](https://github.com/sevki/libcrush/security/code-scanning/2)

To fix this issue, add a `permissions:` block near the top of the workflow YAML (either before or after the `on:` block, but before `jobs:`) specifying minimal required permissions. For a build-and-test workflow like this, the minimal requirement is typically just `contents: read`, which only allows the actions to check out and read the code from the repository. You do not need `write` or any special privileges for typical CI builds/tests unless you are pushing changes, uploading releases, etc. To implement the fix, add:

```yaml
permissions:
  contents: read
```

after the `name` field and before the `on:` block (or at the top of the file, below comments). Only change `.github/workflows/cmake-multi-platform.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
